### PR TITLE
Update get-VTFileReport.ps1

### DIFF
--- a/script/get-VTFileReport.ps1
+++ b/script/get-VTFileReport.ps1
@@ -42,7 +42,9 @@ Function submit-VTHash($VThash)
                     $VTpct = [math]::Round($VTpct,2)
                 }
                 else {
-                    $fore = (get-host).ui.rawui.ForegroundColor
+                    # $fore = (get-host).ui.rawui.ForegroundColor
+                    # regarding to https://stackoverflow.com/questions/26582880/powershell-get-default-foreground-color-for-write-host
+                    $fore = [System.Console]::ForegroundColor
                     $VTpct = 0
                 }
 


### PR DESCRIPTION
hello 
while runing script, I received error:
"Write-Host : Cannot process the color because -1 is not a valid color. Nazwa parametru: value
Rzeczywista wartość to -1.
At C:\Users\%UserName%\Documents\Windows PowerShell\VirusTotal\get-VTFileReport.ps1:53 char:65
+ ...  "Positives   : " -NoNewline; Write-Host $VTresult.positives -f $fore
+                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Write-Host], ArgumentOutOfRangeException
    + FullyQualifiedErrorId : SetInvalidForegroundColor,Microsoft.PowerShell.Commands.WriteHostCommand
"

I suggest solusion from stackOverflow community (https://stackoverflow.com/questions/26582880/powershell-get-default-foreground-color-for-write-host)

Thank you for your usefull tool
Best regards
--
Pawel